### PR TITLE
CI scanning directories

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -4,12 +4,34 @@ on:
     branches: [main]
   pull_request:
 jobs:
+  list-projects:
+    runs-on: ubuntu-latest
+    outputs:
+      dirs: ${{ steps.list-directories.outputs.result }}
+      has_dirs: ${{ steps.list-directories.outputs.has_dirs }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        id: list-directories
+        with:
+          script: |
+            const fs = require('fs');
+            const dirs = fs.readdirSync('.', { withFileTypes: true })
+              .filter(dirent => dirent.isDirectory())
+              .filter(dirent => !dirent.name.startsWith('.'))
+              .map(dirent => dirent.name);
+            const hasDirs = dirs.length > 0;
+            core.setOutput('has_dirs', hasDirs);
+            return JSON.stringify(dirs);
+          result-encoding: string
+
   verify:
+    needs: list-projects
+    if: needs.list-projects.outputs.has_dirs == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project: []
-
+        project: ${{ fromJson(needs.list-projects.outputs.dirs) }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This makes the CI scan the directories, so when we add a new project we don't need to add it to the CI manually